### PR TITLE
Call scopes with a string or array with additional constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ We proudly support the community by developing Laravel packages and giving them 
 
 ## Blogpost
 
-
 If you want to know more about the background of this package, please read [the blogpost](https://protone.media/blog/stop-duplicating-your-eloquent-query-scopes-and-constraints-re-use-them-as-select-statements-with-a-new-laravel-package).
 
 ## Installation
@@ -42,7 +41,6 @@ composer require protonemedia/laravel-eloquent-scope-as-select
 ```
 
 Add the `macro` to the query builder, for example, in your `AppServiceProvider`:
-
 
 ```php
 use ProtoneMedia\LaravelEloquentScopeAsSelect\ScopeAsSelect;
@@ -57,6 +55,37 @@ By default, the name of the macro is `addScopeAsSelect`, but you can customize i
 
 ```php
 ScopeAsSelect::addMacro('withScopeAsSubQuery');
+```
+
+## Short API description
+
+For a more practical explanation, check out the [#usage](usage) section below.
+
+Using a Closure:
+```php
+$posts = Post::addScopeAsSelect('is_published', function ($query) {
+    $query->published();
+})->get();
+```
+
+Using a string:
+```php
+$posts = Post::addScopeAsSelect('is_published', 'published')->get();
+```
+
+Using an array to use multiple scopes:
+```php
+$posts = Post::addScopeAsSelect('is_popular_and_published', ['popular', 'published'])->get();
+```
+
+Using an associative array to use dynamic scopes:
+```php
+$posts = Post::addScopeAsSelect('is_announcement', ['ofType' => 'announcement'])->get();
+```
+
+There's an optional third argument to flip the result:
+```php
+$posts = Post::addScopeAsSelect('is_not_announcement', ['ofType' => 'announcement'], false)->get();
 ```
 
 ## Usage
@@ -169,6 +198,24 @@ Post::query()
 
         $isRecentAndPopular = $post->is_recent_and_popular;
     });
+```
+
+### Shortcuts
+
+Instead of using a Closure, there are some shortcuts you could use:
+
+```php
+Post::addScopeAsSelect('is_published', function ($query) {
+    $query->published();
+});
+
+// is equal to:
+
+Post::addScopeAsSelect('is_published', 'published');
+
+// or:
+
+Post::addScopeAsSelect('is_published', ['published']);
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ScopeAsSelect::addMacro('withScopeAsSubQuery');
 
 ## Short API description
 
-For a more practical explanation, check out the [#usage](usage) section below.
+For a more practical explanation, check out the [usage](#usage) section below.
 
 Using a Closure:
 ```php
@@ -73,14 +73,22 @@ Using a string:
 $posts = Post::addScopeAsSelect('is_published', 'published')->get();
 ```
 
-Using an array to use multiple scopes:
+Using an array to call multiple scopes:
 ```php
 $posts = Post::addScopeAsSelect('is_popular_and_published', ['popular', 'published'])->get();
 ```
 
-Using an associative array to use dynamic scopes:
+Using an associative array to call dynamic scopes:
 ```php
 $posts = Post::addScopeAsSelect('is_announcement', ['ofType' => 'announcement'])->get();
+```
+
+Using an associative array to mix (dynamic) scopes:
+```php
+$posts = Post::addScopeAsSelect('is_published_announcement', [
+    'published',
+    'ofType' => 'announcement'
+])->get();
 ```
 
 There's an optional third argument to flip the result:
@@ -209,11 +217,14 @@ Post::addScopeAsSelect('is_published', function ($query) {
     $query->published();
 });
 
-// is equal to:
+// is the same as:
 
 Post::addScopeAsSelect('is_published', 'published');
+```
 
-// or:
+Post::addScopeAsSelect('is_published', function ($query) {
+    $query->published();
+})
 
 Post::addScopeAsSelect('is_published', ['published']);
 ```

--- a/src/NegativeNullableBooleanCaster.php
+++ b/src/NegativeNullableBooleanCaster.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace ProtoneMedia\LaravelEloquentScopeAsSelect;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class NegativeNullableBooleanCaster implements CastsAttributes
+{
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return !(bool) $value;
+    }
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+}

--- a/src/ScopeAsSelect.php
+++ b/src/ScopeAsSelect.php
@@ -19,19 +19,28 @@ class ScopeAsSelect
         return $value;
     }
 
+    /**
+     * Returns a callable that applies the scope and arguments
+     * to the given query builder.
+     *
+     * @param mixed $value
+     * @return callable
+     */
     public static function makeCallable($value): callable
     {
+        // We both allow single and multiple scopes...
         $scopes = Arr::wrap($value);
 
         return function ($query) use ($scopes) {
-            foreach ($scopes as $key => $scope) {
-                $arguments = [];
-
-                if (is_string($key)) {
-                    $arguments = Arr::wrap($scope);
-
-                    $scope = $key;
+            // If $scope is numeric, there are no arguments, and we can
+            // safely assume the scope is in the $arguments variable.
+            foreach ($scopes as $scope => $arguments) {
+                if (is_numeric($scope)) {
+                    [$scope, $arguments] = [$arguments, null];
                 }
+
+                // As we allow a constraint to be a single arguments.
+                $arguments = Arr::wrap($arguments);
 
                 $query->{$scope}(...$arguments);
             }
@@ -40,32 +49,44 @@ class ScopeAsSelect
         };
     }
 
+    /**
+     * Adds a macro to the query builder.
+     *
+     * @param string $name
+     * @return void
+     */
     public static function addMacro(string $name = 'addScopeAsSelect')
     {
-        Builder::macro($name, function (string $name, $withQuery): Builder {
+        Builder::macro($name, function (string $name, $withQuery, bool $exists = true): Builder {
             $callable = is_callable($withQuery)
                 ? $withQuery
                 : ScopeAsSelect::makeCallable($withQuery);
 
+            // We do this to make sure the $query variable is an Eloquent Query Builder.
             $query = ScopeAsSelect::builder($this);
 
             $originalTable = $query->getModel()->getTable();
 
+            // Instantiate a new model that uses the aliased table.
             $aliasedTable = "{$name}_{$originalTable}";
             $aliasedModel = $query->newModelInstance()->setTable($aliasedTable);
 
-            $subSelect = $aliasedModel::query()->setModel($aliasedModel);
+            // Query the model and explicitly set the targetted table, as the model's table
+            // is just the aliased table with the 'as' statement.
+            $subSelect = $aliasedModel::query();
             $subSelect->getQuery()->from("{$originalTable} as {$aliasedTable}");
 
+            // Apply the where constraint based on the model's key name and apply the $callable.
             $subSelect
                 ->select(DB::raw(1))
                 ->whereColumn($aliasedModel->getQualifiedKeyName(), $query->getModel()->getQualifiedKeyName())
                 ->limit(1)
                 ->tap(fn ($query) => $callable($query));
 
+            // Add the subquery and query-time cast.
             return $query
                 ->addSelect([$name => $subSelect])
-                ->withCasts([$name => NullableBooleanCaster::class]);
+                ->withCasts([$name => $exists ? NullableBooleanCaster::class : NegativeNullableBooleanCaster::class]);
         });
     }
 }

--- a/tests/Comment.php
+++ b/tests/Comment.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 

--- a/tests/Post.php
+++ b/tests/Post.php
@@ -11,13 +11,23 @@ class Post extends Model
         return $this->hasMany(Comment::class);
     }
 
+    public function scopeTitleIs($query, $title)
+    {
+        $query->where($query->qualifyColumn('title'), $title);
+    }
+
     public function scopeTitleIsFoo($query)
     {
-        $query->where($query->qualifyColumn('title'), 'foo');
+        $query->titleIs('foo');
+    }
+
+    public function scopeHasMoreCommentsThan($query, $value)
+    {
+        $query->has('comments', '>', $value);
     }
 
     public function scopeHasSixOrMoreComments($query)
     {
-        $query->has('comments', '>=', 6);
+        $query->hasMoreCommentsThan(5);
     }
 }

--- a/tests/Post.php
+++ b/tests/Post.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 

--- a/tests/ScopeAsSelectTest.php
+++ b/tests/ScopeAsSelectTest.php
@@ -4,6 +4,26 @@ namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 
 class ScopeAsSelectTest extends TestCase
 {
+    private function prepareFourPosts(): array
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'foo']);
+        $postC = Post::create(['title' => 'bar']);
+        $postD = Post::create(['title' => 'bar']);
+
+        foreach (range(1, 5) as $i) {
+            $postA->comments()->create(['body' => 'ok']);
+            $postC->comments()->create(['body' => 'ok']);
+        }
+
+        foreach (range(1, 10) as $i) {
+            $postB->comments()->create(['body' => 'ok']);
+            $postD->comments()->create(['body' => 'ok']);
+        }
+
+        return [$postA, $postB, $postC, $postD];
+    }
+
     /** @test */
     public function it_can_add_a_scope_as_a_select()
     {
@@ -17,6 +37,55 @@ class ScopeAsSelectTest extends TestCase
 
         $this->assertTrue($posts->get(0)->title_is_foo);
         $this->assertFalse($posts->get(1)->title_is_foo);
+    }
+
+    /** @test */
+    public function it_can_add_a_scope_by_using_the_name()
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'bar']);
+
+        $posts = Post::query()
+            ->addScopeAsSelect('title_is_foo', 'titleIsFoo')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertTrue($posts->get(0)->title_is_foo);
+        $this->assertFalse($posts->get(1)->title_is_foo);
+    }
+
+    /** @test */
+    public function it_can_add_multiple_scopes_by_using_an_array()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->addScopeAsSelect('title_is_foo_and_has_six_comments_or_more', ['titleIsFoo', 'hasSixOrMoreComments'])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertFalse($posts->get(0)->title_is_foo_and_has_six_comments_or_more);
+        $this->assertTrue($posts->get(1)->title_is_foo_and_has_six_comments_or_more);
+        $this->assertFalse($posts->get(2)->title_is_foo_and_has_six_comments_or_more);
+        $this->assertFalse($posts->get(3)->title_is_foo_and_has_six_comments_or_more);
+    }
+    /** @test */
+    public function it_can_add_multiple_dynamic_scopes_by_using_an_array()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->addScopeAsSelect('title_is_foo_and_has_more_than_five_comments', [
+                'titleIsFoo',
+                'hasMoreCommentsThan' => 5,
+            ])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertFalse($posts->get(0)->title_is_foo_and_has_more_than_five_comments);
+        $this->assertTrue($posts->get(1)->title_is_foo_and_has_more_than_five_comments);
+        $this->assertFalse($posts->get(2)->title_is_foo_and_has_more_than_five_comments);
+        $this->assertFalse($posts->get(3)->title_is_foo_and_has_more_than_five_comments);
     }
 
     /** @test */
@@ -53,20 +122,7 @@ class ScopeAsSelectTest extends TestCase
     /** @test */
     public function it_can_do_inline_contraints_as_well()
     {
-        $postA = Post::create(['title' => 'foo']);
-        $postB = Post::create(['title' => 'foo']);
-        $postC = Post::create(['title' => 'bar']);
-        $postD = Post::create(['title' => 'bar']);
-
-        foreach (range(1, 5) as $i) {
-            $postA->comments()->create(['body' => 'ok']);
-            $postC->comments()->create(['body' => 'ok']);
-        }
-
-        foreach (range(1, 10) as $i) {
-            $postB->comments()->create(['body' => 'ok']);
-            $postD->comments()->create(['body' => 'ok']);
-        }
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
 
         $posts = Post::query()
             ->addScopeAsSelect('title_is_foo_and_has_six_comments_or_more', function ($query) {
@@ -84,20 +140,7 @@ class ScopeAsSelectTest extends TestCase
     /** @test */
     public function it_can_mix_scopes_outside_of_the_closure()
     {
-        $postA = Post::create(['title' => 'foo']);
-        $postB = Post::create(['title' => 'foo']);
-        $postC = Post::create(['title' => 'bar']);
-        $postD = Post::create(['title' => 'bar']);
-
-        foreach (range(1, 5) as $i) {
-            $postA->comments()->create(['body' => 'ok']);
-            $postC->comments()->create(['body' => 'ok']);
-        }
-
-        foreach (range(1, 10) as $i) {
-            $postB->comments()->create(['body' => 'ok']);
-            $postD->comments()->create(['body' => 'ok']);
-        }
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
 
         $posts = Post::query()
             ->where('title', 'foo')

--- a/tests/ScopeAsSelectTest.php
+++ b/tests/ScopeAsSelectTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 
@@ -40,6 +40,21 @@ class ScopeAsSelectTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_a_scope_as_a_select_and_cast_inversed()
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'bar']);
+
+        $posts = Post::query()
+            ->addScopeAsSelect('title_is_foo', fn ($query) => $query->titleIsFoo(), false)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertFalse($posts->get(0)->title_is_foo);
+        $this->assertTrue($posts->get(1)->title_is_foo);
+    }
+
+    /** @test */
     public function it_can_add_a_scope_by_using_the_name()
     {
         $postA = Post::create(['title' => 'foo']);
@@ -69,6 +84,7 @@ class ScopeAsSelectTest extends TestCase
         $this->assertFalse($posts->get(2)->title_is_foo_and_has_six_comments_or_more);
         $this->assertFalse($posts->get(3)->title_is_foo_and_has_six_comments_or_more);
     }
+
     /** @test */
     public function it_can_add_multiple_dynamic_scopes_by_using_an_array()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 

--- a/tests/Video.php
+++ b/tests/Video.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
 

--- a/tests/create_tables.php
+++ b/tests/create_tables.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;


### PR DESCRIPTION
Instead of

```php
$posts = Post::addScopeAsSelect('is_published', fn ($query) => $query->published())->get();
```

You can do:

```php
$posts = Post::addScopeAsSelect('is_published', 'published')->get();
```

Multiple scopes:

```php
$posts = Post::addScopeAsSelect('is_popular_and_published', ['popular', 'published'])->get();
```

And even use dynamic scopes:

```php
$posts = Post::addScopeAsSelect('is_popular_and_published_this_year', [
    'popular', 
    'publishedInYear' => date('Y')
])->get();

$posts = Post::addScopeAsSelect('is_published_in_nineties', [
    'publishedBetweenYears' => [1990, 2000]
])->get();
```
