### PR TITLE
[WIP] Support for flipping scopes

### DIFF
--- a/src/WhereNot.php
+++ b/src/WhereNot.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace ProtoneMedia\LaravelEloquentScopeAsSelect;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+
+class WhereNot
+{
+    /**
+     * The count for each table.
+     *
+     * @var array
+     */
+    protected static $tableSubCount = [];
+
+    /**
+     * Helper method for code completion.
+     *
+     * @param mixed $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public static function builder($value): Builder
+    {
+        return $value;
+    }
+
+    /**
+     * Returns a callable that applies the scope and arguments
+     * to the given query builder.
+     *
+     * @param mixed $value
+     * @return callable
+     */
+    public static function makeCallable($value): callable
+    {
+        // We both allow single and multiple scopes...
+        $scopes = Arr::wrap($value);
+
+        return function ($query) use ($scopes) {
+            // If $scope is numeric, there are no arguments, and we can
+            // safely assume the scope is in the $arguments variable.
+            foreach ($scopes as $scope => $arguments) {
+                if (is_numeric($scope)) {
+                    [$scope, $arguments] = [$arguments, null];
+                }
+
+                // As we allow a constraint to be a single arguments.
+                $arguments = Arr::wrap($arguments);
+
+                $query->{$scope}(...$arguments);
+            }
+
+            return $query;
+        };
+    }
+
+    /**
+     * Makes an alias for the given table.
+     *
+     * @param string $table
+     * @return string
+     */
+    public static function getTableAlias($table): string
+    {
+        if (!array_key_exists($table, static::$tableSubCount)) {
+            static::$tableSubCount[$table] = 0;
+        }
+
+        $count = static::$tableSubCount[$table]++;
+
+        return "where_scope_not_{$count}_{$table}";
+    }
+
+    /**
+     * Adds a macro to the query builder.
+     *
+     * @param string $name
+     * @return void
+     */
+    public static function addMacro(string $name = 'whereNot')
+    {
+        Builder::macro($name, function ($withQuery): Builder {
+            $callable = is_callable($withQuery)
+                ? $withQuery
+                : WhereNot::makeCallable($withQuery);
+
+            // We do this to make sure the $query variable is an Eloquent Query Builder.
+            $builder = WhereNot::builder($this);
+
+            return $builder->whereNotExists(function ($query) use ($callable, $builder) {
+                $eloquentBuilder = new Builder($query);
+                $eloquentBuilder->setModel($builder->getModel());
+
+                $originalTable = $eloquentBuilder->getModel()->getTable();
+
+                // Instantiate a new model that uses the aliased table.
+                $aliasedTable = WhereNot::getTableAlias($originalTable);
+                $aliasedModel = $eloquentBuilder->newModelInstance()->setTable($aliasedTable);
+
+                // Apply the where constraint based on the model's key name and apply the $callable.
+                $eloquentBuilder
+                    ->select(DB::raw(1))
+                    ->from($originalTable, $aliasedTable)
+                    ->whereColumn($aliasedModel->getQualifiedKeyName(), 'posts.id')
+                    ->limit(1)
+                    ->tap(fn ($query) => $callable($query));
+            });
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use PDO;
 use ProtoneMedia\LaravelEloquentScopeAsSelect\ScopeAsSelect;
+use ProtoneMedia\LaravelEloquentScopeAsSelect\WhereNot;
 
 class TestCase extends OrchestraTestCase
 {
@@ -16,6 +17,7 @@ class TestCase extends OrchestraTestCase
         Model::unguard();
 
         ScopeAsSelect::addMacro();
+        WhereNot::addMacro();
 
         $this->app['config']->set('app.key', 'base64:yWa/ByhLC/GUvfToOuaPD7zDwB64qkc/QkaQOrT5IpE=');
 

--- a/tests/WhereNotTest.php
+++ b/tests/WhereNotTest.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types=1);
+
+namespace ProtoneMedia\LaravelEloquentScopeAsSelect\Tests;
+
+class WhereNotTest extends TestCase
+{
+    private function prepareFourPosts(): array
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'foo']);
+        $postC = Post::create(['title' => 'bar']);
+        $postD = Post::create(['title' => 'bar']);
+
+        foreach (range(1, 5) as $i) {
+            $postA->comments()->create(['body' => 'ok']);
+            $postC->comments()->create(['body' => 'ok']);
+        }
+
+        foreach (range(1, 10) as $i) {
+            $postB->comments()->create(['body' => 'ok']);
+            $postD->comments()->create(['body' => 'ok']);
+        }
+
+        return [$postA, $postB, $postC, $postD];
+    }
+
+    /** @test */
+    public function it_can_invert_a_scope()
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'bar']);
+
+        $posts = Post::query()
+            ->whereNot(fn ($query) => $query->titleIsFoo())
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(1, $posts);
+        $this->assertTrue($posts->contains($postB));
+    }
+
+    /** @test */
+    public function it_can_invert_a_scope_by_using_the_name()
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'bar']);
+
+        $posts = Post::query()
+            ->whereNot('titleIsFoo')
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(1, $posts);
+        $this->assertTrue($posts->contains($postB));
+    }
+
+    /** @test */
+    public function it_can_invert_multiple_scopes_by_using_an_array()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->whereNot(['titleIsFoo', 'hasSixOrMoreComments'])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->contains($postA));
+        $this->assertTrue($posts->contains($postC));
+        $this->assertTrue($posts->contains($postD));
+    }
+
+    /** @test */
+    public function it_can_invert_multiple_dynamic_scopes_by_using_an_array()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->whereNot([
+                'titleIsFoo',
+                'hasMoreCommentsThan' => 5,
+            ])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->contains($postA));
+        $this->assertTrue($posts->contains($postC));
+        $this->assertTrue($posts->contains($postD));
+    }
+
+    /** @test */
+    public function it_can_invert_multiple_dynamic_scopes_by_using_an_array_of_scope_arguments()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->whereNot([
+                'titleIsFoo',
+                'hasMoreCommentsThan' => [5],
+            ])
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->contains($postA));
+        $this->assertTrue($posts->contains($postC));
+        $this->assertTrue($posts->contains($postD));
+    }
+
+    /** @test */
+    public function it_can_invert_multiple_and_has_relation_scopes()
+    {
+        $postA = Post::create(['title' => 'foo']);
+        $postB = Post::create(['title' => 'bar']);
+
+        foreach (range(1, 10) as $i) {
+            $postA->comments()->create(['body' => 'ok']);
+        }
+
+        foreach (range(1, 5) as $i) {
+            $postB->comments()->create(['body' => 'ok']);
+        }
+
+        $posts = Post::query()
+            ->whereNot(function ($query) {
+                $query->hasSixOrMoreComments();
+            })
+            ->whereNot(function ($query) {
+                $query->titleIsFoo();
+            })
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(1, $posts);
+        $this->assertTrue($posts->contains($postB));
+    }
+
+    /** @test */
+    public function it_can_invert_inline_contraints_as_well()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->whereNot(function ($query) {
+                $query->where('title', 'foo')->has('comments', '>=', 6);
+            })
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->contains($postA));
+        $this->assertTrue($posts->contains($postC));
+        $this->assertTrue($posts->contains($postD));
+    }
+
+    /** @test */
+    public function it_can_mix_scopes_outside_of_the_closure()
+    {
+        [$postA, $postB, $postC, $postD] = $this->prepareFourPosts();
+
+        $posts = Post::query()
+            ->where('title', 'foo')
+            ->whereNot(function ($query) {
+                $query->has('comments', '>=', 6);
+            })
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(1, $posts);
+        $this->assertTrue($posts->contains($postA));
+    }
+}


### PR DESCRIPTION
**Solution for https://github.com/protonemedia/laravel-eloquent-scope-as-select/issues/3**:

Eloquent model:

```php
class Post extends Model
{
    public function user()
    {
        return $this->belongsTo(User::class);
    }

    public function comments()
    {
        return $this->hasMany(Comment::class);
    }

    public function scopeFrontPage($query)
    {
        $query->where('is_public', 1)
            ->where('votes', '>', 100)
            ->has('comments', '>=', 20)            
            ->whereHas('user', fn($user) => $user->isAdmin())
            ->whereYear('published_at', date('Y'));
    }
}
```

The `whereNot` method has the same syntax as the `addScopeAsSelect` method:

```php
$nonFrontPagePosts = Post::whereNot('frontPage')->get();
```